### PR TITLE
Resolve issues with readme file being committed

### DIFF
--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -84,6 +84,11 @@ main() {
 		exit 0
 	fi
 
+	if [[ -z $(git status --porcelain) ]]; then
+		echo "No changes to commit. Exiting."
+		exit 1
+	fi
+
 	echo "Committing changes and pushing to the repository."
 	git commit -m "Update Tested Up To version to $CURRENT_WP_VERSION"
 	git push origin "$BRANCH_NAME"

--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -76,7 +76,7 @@ main() {
 	git config user.name "github-actions"
 	git config user.email "github-actions@github.com"
 	git checkout -b "$BRANCH_NAME"
-	git add "${PLUGIN_PATH}/readme.txt" "${PLUGIN_PATH}/README.md" || true
+	git add "${PLUGIN_PATH}/"{readme,README}.* || true
 
 	# Bail before committing anything if we're dry-running.
 	if [[ "${DRY_RUN}" == "true" ]]; then


### PR DESCRIPTION
Attempts to address an issue where the files weren't being committed because we were trying to add both in the same `git add`. If one of the two files did not exist, the `git add` would fail, potentially causing nothing to be added to the branch.