### PR TITLE
Add support for user-defined filenames [major]

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ Only used in self-testing. If passed, this will not actually create a PR against
 
 #### `gh-token`
 The GitHub token to use for creating a PR. If not specified, the action will use the default GitHub token.
+
+#### `filenames`
+A comma-separated list of filenames to check for the "Tested Up To" version. If not specified, the action will use `readme.txt` and `README.md`.

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: The GitHub token to use for creating a pull request.
     required: false
     default: ${{ github.token }}
+  filenames:
+    description: The filenames to check for the tested up to version. Default is 'readme.txt,README.md'.
+    required: false
+    default: 'readme.txt,README.md'
 runs:
   using: composite
   steps:
@@ -35,5 +39,6 @@ runs:
         DRY_RUN: ${{ inputs.dry-run }}
         WORKFLOW_PATH: ${{ github.workspace }}
         GH_TOKEN: ${{ inputs.gh-token }}
+        FILENAMES: ${{ inputs.filenames }}
       run: bash ${{ github.action_path }}/bin/validate-plugin-version.sh
     


### PR DESCRIPTION
This pull request adds support for user-defined filenames to check for the "Tested Up To" version. Previously, the action only checked `readme.txt` and `README.md` files. Now, you can specify a comma-separated list of filenames to check. This allows for more flexibility in determining the "Tested Up To" version for a plugin.