### PR TITLE
[minor] Preserve whitespace and add branch as an input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: The filenames to check for the tested up to version. Default is 'readme.txt,README.md'.
     required: false
     default: 'readme.txt,README.md'
+  branch:
+    description: The branch to use as the base for PRs and commit the changes back to.
+    required: false
+    default: 'main'
 runs:
   using: composite
   steps:
@@ -40,5 +44,6 @@ runs:
         WORKFLOW_PATH: ${{ github.workspace }}
         GH_TOKEN: ${{ inputs.gh-token }}
         FILENAMES: ${{ inputs.filenames }}
+        BRANCH: ${{ inputs.branch }}
       run: bash ${{ github.action_path }}/bin/validate-plugin-version.sh
     

--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -78,14 +78,10 @@ main() {
 		exit 0
 	fi
 
-	if [[ "${DRY_RUN}" == "true" ]]; then
-		BRANCH=$GITHUB_REF
-	fi
-
-	echo "Creating a new branch ${BRANCH_NAME} off of ${BRANCH} and pushing changes."
+	echo "Creating a new branch $BRANCH_NAME and pushing changes."
 	git config user.name "github-actions"
 	git config user.email "github-actions@github.com"
-	git checkout -b "$BRANCH_NAME" "$BRANCH"
+	git checkout -b "$BRANCH_NAME"
 
 	# Add updated files to git
 	for filename in "${FILENAMES_ARRAY[@]}"; do
@@ -112,7 +108,7 @@ main() {
 	git commit -m "Update Tested Up To version to $CURRENT_WP_VERSION"
 	git push origin "$BRANCH_NAME"
 
-	gh pr create --title "Update Tested Up To version to $CURRENT_WP_VERSION" --body "This pull request updates the \"Tested up to\" version in specified files (${FILENAMES}) to match the current WordPress version $CURRENT_WP_VERSION."
+	gh pr create --title "Update Tested Up To version to $CURRENT_WP_VERSION" --body "This pull request updates the \"Tested up to\" version in specified files (${FILENAMES}) to match the current WordPress version $CURRENT_WP_VERSION." --base $BRANCH
 }
 
 main

--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -47,7 +47,7 @@ main() {
 	
 	# Compare versions using PHP
 	if php -r "exit(version_compare('$TESTED_UP_TO', '$CURRENT_WP_VERSION', '>=') ? 0 : 1);"; then
-		echo "Tested up to version matches or is greater than the current WordPress version. Nothing to do here."
+		echo "Tested up to version matches or is greater than the current WordPress version. Check passed."
 		exit
 	fi
 	echo "Tested up to version ($TESTED_UP_TO) is less than current WordPress version ($CURRENT_WP_VERSION)."
@@ -61,9 +61,9 @@ main() {
 		if [[ -f "$full_path" ]]; then
 			echo "Updating 'Tested up to' version in $full_path"
 			if [[ "$OSTYPE" == "darwin"* ]]; then
-				sed -i '' -E "s/(Tested up to: ).*/\1$CURRENT_WP_VERSION/" "$full_path"
+				sed -i '' -E "s/(Tested up to: )([0-9.]+)([[:space:]]*)/\1$CURRENT_WP_VERSION\3/" "$full_path"
 			else
-				sed -i -E "s/(Tested up to: ).*/\1$CURRENT_WP_VERSION/" "$full_path"
+				sed -i -E "s/(Tested up to: )([0-9.]+)([[:space:]]*)/\1$CURRENT_WP_VERSION\3/" "$full_path"
 			fi
 		fi
 	done

--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -108,7 +108,7 @@ main() {
 	git commit -m "Update Tested Up To version to $CURRENT_WP_VERSION"
 	git push origin "$BRANCH_NAME"
 
-	gh pr create --title "Update Tested Up To version to $CURRENT_WP_VERSION" --body "This pull request updates the \"Tested up to\" version in specified files (${FILENAMES}) to match the current WordPress version $CURRENT_WP_VERSION." --base $BRANCH
+	gh pr create --title "Update Tested Up To version to $CURRENT_WP_VERSION" --body "This pull request updates the \"Tested up to\" version in specified files (${FILENAMES}) to match the current WordPress version $CURRENT_WP_VERSION." --base "$BRANCH"
 }
 
 main

--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -53,9 +53,6 @@ main() {
 	echo "Tested up to version ($TESTED_UP_TO) is less than current WordPress version ($CURRENT_WP_VERSION)."
 	echo "Updating files with new Tested up to version."
 
-	echo "Checkout out the ${BRANCH} branch."
-	git checkout "${BRANCH}"
-
 	# Update each specified filename if it exists
 	for filename in "${FILENAMES_ARRAY[@]}"; do
 		trimmed_filename=$(echo "$filename" | xargs) # Trim whitespace
@@ -81,10 +78,10 @@ main() {
 		exit 0
 	fi
 
-	echo "Creating a new branch $BRANCH_NAME and pushing changes."
+	echo "Creating a new branch ${BRANCH_NAME} off of ${BRANCH} and pushing changes."
 	git config user.name "github-actions"
 	git config user.email "github-actions@github.com"
-	git checkout -b "$BRANCH_NAME"
+	git checkout -b "$BRANCH_NAME" "$BRANCH"
 
 	# Add updated files to git
 	for filename in "${FILENAMES_ARRAY[@]}"; do

--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -53,6 +53,9 @@ main() {
 	echo "Tested up to version ($TESTED_UP_TO) is less than current WordPress version ($CURRENT_WP_VERSION)."
 	echo "Updating files with new Tested up to version."
 
+	echo "Checkout out the ${BRANCH} branch."
+	git checkout "${BRANCH}"
+
 	# Update each specified filename if it exists
 	for filename in "${FILENAMES_ARRAY[@]}"; do
 		trimmed_filename=$(echo "$filename" | xargs) # Trim whitespace

--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -78,6 +78,10 @@ main() {
 		exit 0
 	fi
 
+	if [[ "${DRY_RUN}" == "true" ]]; then
+		BRANCH=$GITHUB_REF
+	fi
+
 	echo "Creating a new branch ${BRANCH_NAME} off of ${BRANCH} and pushing changes."
 	git config user.name "github-actions"
 	git config user.email "github-actions@github.com"


### PR DESCRIPTION
This pull request fixes two issues.

* The first commit addresses preserving whitespace in files, ensuring that, in markdown files, whitespaces represent line breaks correctly. 
* The second commit adds a new input called "branch" which allows users to specify the branch to use as the base for pull requests and commit the changes back to. This allows plugins to use the correct base branch rather than the default branch.
