### PR TITLE
Default to draft PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ A comma-separated list of filenames to check for the "Tested Up To" version. If 
 #### `branch`
 The branch to create the PR against. If not specified, the action will use the branch the workflow is running on (default branch for cron-triggered workflows).
 
+#### `pr-status`
+The status to set on the PR. If not specified, the action will create a _draft_ PR.
+
 ## Permissions
 
 The `write` permissions on `contents` and `pull-requests` are important. They are required for the action to commit the changes back to the repository and open a pull request. The only files affected by the action are files named `readme.txt`, `README.md` or those files matching the pattern (looking for "Tested Up To" in the file) that have been specified in the `filenames` input. 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A comma-separated list of filenames to check for the "Tested Up To" version. If 
 The branch to create the PR against. If not specified, the action will use the branch the workflow is running on (default branch for cron-triggered workflows).
 
 #### `pr-status`
-The status to set on the PR. If not specified, the action will create a _draft_ PR.
+The status to set on the PR. If not specified, the action will create a _draft_ PR. Accepts `draft` or `open`.
 
 ## Permissions
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: 'main'
   pr-status:
-    description: The status of the PR to create. Default is 'draft'.
+    description: The status of the PR to create. Default is 'draft'. Accepts 'draft' or 'open'.
     required: false
     default: 'draft'
 runs:
@@ -49,5 +49,6 @@ runs:
         GH_TOKEN: ${{ inputs.gh-token }}
         FILENAMES: ${{ inputs.filenames }}
         BRANCH: ${{ inputs.branch }}
+        PR_STATUS: ${{ inputs.pr-status }}
       run: bash ${{ github.action_path }}/bin/validate-plugin-version.sh
     

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: The branch to use as the base for PRs and commit the changes back to.
     required: false
     default: 'main'
+  pr-status:
+    description: The status of the PR to create. Default is 'draft'.
+    required: false
+    default: 'draft'
 runs:
   using: composite
   steps:

--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -138,7 +138,11 @@ main() {
 	BASE_BRANCH="${BRANCH:-$DEFAULT_BRANCH}"
 
 	echo "Creating a pull request with base branch $BASE_BRANCH."
-	gh pr create --title "Update Tested Up To version to $CURRENT_WP_VERSION" --body "This pull request updates the \"Tested up to\" version in specified files (${FILENAMES}) to match the current WordPress version $CURRENT_WP_VERSION." --base "$BASE_BRANCH" --draft
+	local PR_OPTIONS="--title \"Update Tested Up To version to $CURRENT_WP_VERSION\" --body \"This pull request updates the 'Tested up to' version in specified files (${FILENAMES}) to match the current WordPress version $CURRENT_WP_VERSION.\" --base \"$BASE_BRANCH\""
+	if [[ "${PR_STATUS:-}" != "open" ]]; then
+		PR_OPTIONS="$PR_OPTIONS --draft"
+	fi
+	gh pr create $PR_OPTIONS
 }
 
 main

--- a/bin/validate-plugin-version.sh
+++ b/bin/validate-plugin-version.sh
@@ -138,7 +138,7 @@ main() {
 	BASE_BRANCH="${BRANCH:-$DEFAULT_BRANCH}"
 
 	echo "Creating a pull request with base branch $BASE_BRANCH."
-	gh pr create --title "Update Tested Up To version to $CURRENT_WP_VERSION" --body "This pull request updates the \"Tested up to\" version in specified files (${FILENAMES}) to match the current WordPress version $CURRENT_WP_VERSION." --base "$BASE_BRANCH"
+	gh pr create --title "Update Tested Up To version to $CURRENT_WP_VERSION" --body "This pull request updates the \"Tested up to\" version in specified files (${FILENAMES}) to match the current WordPress version $CURRENT_WP_VERSION." --base "$BASE_BRANCH" --draft
 }
 
 main


### PR DESCRIPTION
Sometimes automations on a PR don't run if the PR is opened by a robot. 

In those cases, a common workaround is having the robot open the PR as a draft so a human can open/set the PR as Ready and trigger the workflows.

This PR defaults the PR status to `draft` unless `open` is explicitly passed.